### PR TITLE
Adds ability to remove cells without deleting PFObjects

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -184,6 +184,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeObjectsAtIndexPaths:(nullable NSArray<NSIndexPath *> *)indexPaths animated:(BOOL)animated;
 
 /**
+ Removes the cell at the specified indexPath, with or without animation.
+ Important: This method only removes the cell. It does not delete any PFObject on the backend. 
+ */
+- (void)removeCellAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated;
+
+/**
+ Removes the cells at the specified indexPaths, with or without animation.
+ Important: This method only removes the cells. It does not delete any PFObject on the backend.
+ */
+- (void)removeCellsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
+
+/**
  Clears the table of all objects.
  */
 - (void)clear;

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -367,7 +367,14 @@
 }
 
 - (void)removeCellsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated {
-    [_mutableObjects removeObjectAtIndexPaths:indexPaths];
+    NSMutableIndexSet *mutableIndexSet = [[NSMutableIndexSet alloc]init];
+    
+    for (NSIndexPath *indexPath in indexPaths) {
+        [mutableIndexSet addIndex:indexPath.row];
+    }
+    
+    [_mutableObjects removeObjectsAtIndexes:mutableIndexSet];
+    
     [self.tableView deleteRowsAtIndexPaths:indexPaths
                           withRowAnimation:animated ? UITableViewRowAnimationAutomatic : UITableViewRowAnimationNone];
 }

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -362,6 +362,16 @@
     [self removeObjectsAtIndexPaths:indexPaths animated:YES];
 }
 
+- (void)removeCellAtIndexPath:(nullable NSIndexPath *)indexPath animated:(BOOL)animated {
+    [self removeCellsAtIndexPaths:@[indexPath] animated: animated];
+}
+
+- (void)removeCellsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated {
+    [_mutableObjects removeObjectAtIndexPaths:indexPaths];
+    [self.tableView deleteRowsAtIndexPaths:indexPaths
+                          withRowAnimation:animated ? UITableViewRowAnimationAutomatic : UITableViewRowAnimationNone];
+}
+
 - (void)removeObjectsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated {
     if (indexPaths.count == 0) {
         return;


### PR DESCRIPTION
I added 2 methods that remove the PFQueryTableViewController tableViewCells without affecting the objects on the backend. 

These methods are perfect for the case when you run a PFCloud function and on completion you want to remove the affected cells, without needing a to call reloadObjects.
