### PR TITLE
Put localizations in resource bundle

### DIFF
--- a/ParseUI.podspec
+++ b/ParseUI.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
                           'ParseUI/Classes/Views/*.h',
                           'ParseUI/Classes/Cells/*.h',
                           'ParseUI/Other/*.h'
-  s.resources  = ['ParseUI/Resources/Localization/*.lproj']
+  s.resource_bundles    = { 'ParseUI' => ['ParseUI/Resources/Localization/*.lproj'] }
   s.frameworks          = 'Foundation',
                           'UIKit',
                           'CoreGraphics',

--- a/ParseUI/Classes/Internal/PFLocalization.m
+++ b/ParseUI/Classes/Internal/PFLocalization.m
@@ -19,16 +19,28 @@
  *
  */
 
-#import <Foundation/Foundation.h>
+#import "PFLocalization.h"
 
-#define PFLocalizedString(key, comment) \
-[PFLocalization localizedStringForKey:key]
+@implementation PFLocalization
 
-/**
- Used by the above macro to fetch a localized string
- */
-@interface PFLocalization : NSObject
++ (NSString *)localizedStringForKey:key {
+    return [[self resourcesBundle] localizedStringForKey:key value:nil table:@"ParseUI"];
+}
 
-+ (NSString *)localizedStringForKey:key;
++ (NSBundle *)resourcesBundle {
+    static NSBundle *bundle;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSBundle *classBundle = [NSBundle bundleForClass:[self class]];
+        NSURL *bundleURL = [classBundle URLForResource:@"ParseUI" withExtension:@"bundle"];
+        
+        if (bundleURL) {
+            bundle = [NSBundle bundleWithURL:bundleURL];
+        } else {
+            bundle = [NSBundle mainBundle];
+        }
+    });
+    return bundle;
+}
 
 @end


### PR DESCRIPTION
The localization files were being put in the main bundle when using Cocoapods. This causes the AppStore to detect these localizations and display the app as supporting these languages even though the app doesn't have fully localized support for these languages.

The solution mentioned [here](https://github.com/CocoaPods/CocoaPods/issues/1301) on Cocoapods is to put the localization files in to a resource bundle.

This change also adds support to save the bundle in a static so each time `PFLocalizedString()` is called we don't do a bundle lookup.
